### PR TITLE
fix SerialName for Units.Knots

### DIFF
--- a/src/main/kotlin/com/openmeteo/api/common/units/Units.kt
+++ b/src/main/kotlin/com/openmeteo/api/common/units/Units.kt
@@ -44,7 +44,7 @@ enum class Units(vararg val alias: @Contextual Any) {
     @SerialName("mph")
     MilesPerHour(WindSpeedUnit.MilesPerHour),
 
-    @SerialName("knots")
+    @SerialName("kn")
     Knots(WindSpeedUnit.Knots),
 
     @SerialName("cm")

--- a/src/test/kotlin/com/openmeteo/api/ForecastTest.kt
+++ b/src/test/kotlin/com/openmeteo/api/ForecastTest.kt
@@ -2,6 +2,7 @@ package com.openmeteo.api
 
 import com.openmeteo.api.common.time.Timezone
 import com.openmeteo.api.common.units.Units
+import com.openmeteo.api.common.units.WindSpeedUnit.Knots
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -15,18 +16,20 @@ class ForecastTest {
             longitude = 4.8910f,
             daily = Forecast.Daily {
                 listOf(
-                    weathercode, sunrise, sunset, temperature2mMax, temperature2mMin
+                    weathercode, sunrise, sunset, temperature2mMax, temperature2mMin,
+                    windspeed10mMax
                 )
             },
+            windSpeedUnit = Knots,
             timezone = Timezone.auto,
             pastDays = 1,
         )
         Forecast(query).getOrThrow().run {
-            assertEquals(52.38f, latitude)
-            assertEquals(4.9f, longitude)
+            assertEquals(52.366f, latitude)
+            assertEquals(4.901f, longitude)
             // assertEquals(utcOffsetSeconds, 7200) // TODO: changes based on summer time?
             assertEquals("Europe/Amsterdam", timezone.id)
-            assertEquals("CEST", timezoneAbbreviation)
+            assertEquals("GMT+1", timezoneAbbreviation)
             assertEquals(17f, elevation)
             assert(
                 dailyUnits.equals(
@@ -37,6 +40,7 @@ class ForecastTest {
                         "sunset" to Units.UnixTime,
                         "temperature_2m_max" to Units.Celsius,
                         "temperature_2m_min" to Units.Celsius,
+                        "windspeed_10m_max" to Units.Knots,
                     )
                 )
             )
@@ -46,6 +50,7 @@ class ForecastTest {
             assertContains(dailyValues, "sunset")
             assertContains(dailyValues, "temperature_2m_max")
             assertContains(dailyValues, "temperature_2m_min")
+            assertContains(dailyValues, "windspeed_10m_max")
         }
     }
 


### PR DESCRIPTION
There is an error when a forecast with `windSpeedUnit = WindSpeedUnit.Knots` is requested

```
Exception in thread "main" kotlinx.serialization.SerializationException: com.openmeteo.api.common.units.Units does not contain element with name 'kn' at path $.hourlyUnits['windspeed_10m']
	at kotlinx.serialization.json.internal.JsonNamesMapKt.getJsonNameIndexOrThrow(JsonNamesMap.kt:107)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeEnum(StreamingJsonDecoder.kt:353)
	at kotlinx.serialization.internal.EnumSerializer.deserialize(Enums.kt:136)
	at kotlinx.serialization.internal.EnumSerializer.deserialize(Enums.kt:102)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:168)
	at kotlinx.serialization.encoding.CompositeDecoder.decodeSerializableElement$default(Decoding.kt:539)
	at kotlinx.serialization.internal.MapLikeSerializer.readElement(CollectionSerializers.kt:111)
	at kotlinx.serialization.internal.MapLikeSerializer.readElement(CollectionSerializers.kt:84)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.readElement$default(CollectionSerializers.kt:51)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.merge(CollectionSerializers.kt:36)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.deserialize(CollectionSerializers.kt:43)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:168)
	at com.openmeteo.api.Forecast$Response$$serializer.deserialize(Forecast.kt:88)
	at com.openmeteo.api.Forecast$Response$$serializer.deserialize(Forecast.kt:88)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:149)
```